### PR TITLE
Update Instruction 2 and 3

### DIFF
--- a/Lesson_7_Project_Scan_Matching_Localization/c3-project/README.md
+++ b/Lesson_7_Project_Scan_Matching_Localization/c3-project/README.md
@@ -14,7 +14,6 @@
     ├── c3-main.cpp
     ├── helper.cpp
     ├── helper.h
-    ├── libcarla-install/
     ├── make-libcarla-install.sh
     ├── map.pcd
     ├── map_loop.pcd
@@ -23,7 +22,7 @@
     ```
 
 
-3. Ensure that the **libcarla-install/** folder is present in your current working directory. The folder contains the static binaries built for the target VM workspace environment. If the folder is missing or corrupt, you can regenerate the files using the following command:
+3. Generate **libcarla-install/** folder by executing below commands in order:
     ```bash
     chmod +x make-libcarla-install.sh
     ./make-libcarla-install.sh


### PR DESCRIPTION
libcarla-install present by default in the repository should be removed and generated afresh each time to avoid compile time errors.